### PR TITLE
Remove unused dotenv import

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -2,7 +2,6 @@ import os
 import logging
 import joblib
 import pandas as pd
-from dotenv import load_dotenv
 from langchain_community.vectorstores import Chroma
 from langchain_experimental.open_clip import OpenCLIPEmbeddings
 


### PR DESCRIPTION
## Summary
- remove unused `dotenv.load_dotenv` import from `data_loader.py`
- confirm only `app.py` calls `load_dotenv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843390480dc83288623bd8537b71ec5