### PR TITLE
Fix missing dotenv dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 langchain==0.1.9
 openai==0.28.1
 pydantic>=1.10.12
+python-dotenv>=1.0.0
 pytest>=7.4.0
 sentence-transformers>=2.2.0
 transformers>=4.31.0


### PR DESCRIPTION
## Summary
- add `python-dotenv` to requirements

## Testing
- `python -m py_compile app.py data_loader.py search.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_68433efe31c08328b5b9d79ec515d543