### PR TITLE
Improve configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ This will generate a local URL to access the app.
 **Note:** The application falls back to an image named `default_image.png` when
  a listing has no associated photo. Ensure `images/default_image.png` exists or
  set the `DEFAULT_IMAGE` environment variable to point to a custom file.
+
+## ⚙️ Configuration
+Create a `.env` file to override any of the following settings:
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `LISTINGS_CSV` | `listings.csv` | Path to the property CSV file |
+| `VECTOR_DB_DIR` | `chroma_db` | Directory holding the vector database |
+| `CACHE_FILE` | `listings_cache.pkl` | Pickle file used for caching the dataframe |
+| `IMAGES_DIR` | `images` | Directory containing listing images |
+| `DEFAULT_IMAGE` | `default_image.png` | Fallback image when a listing photo is missing |
+| `TOP_K` | `5` | Number of search results returned from the vector DB |
  
 ## 📊 How It Works
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 import logging
-from dotenv import load_dotenv
 from data_loader import load_dataframe, load_vector_db
 from search import init_globals
 from ui import create_ui
@@ -12,8 +11,6 @@ def main():
         handlers=[logging.StreamHandler(), logging.FileHandler("app.log")]
     )
 
-    # Load environment
-    load_dotenv()
 
     # Load data
     df, df_dict = load_dataframe()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Paths and files
+LISTINGS_CSV = os.getenv("LISTINGS_CSV", "listings.csv")
+VECTOR_DB_DIR = os.getenv("VECTOR_DB_DIR", "chroma_db")
+CACHE_FILE = os.getenv("CACHE_FILE", "listings_cache.pkl")
+IMAGES_DIR = os.getenv("IMAGES_DIR", "images")
+DEFAULT_IMAGE = os.getenv("DEFAULT_IMAGE", "default_image.png")
+
+# Search settings
+TOP_K = int(os.getenv("TOP_K", "5"))

--- a/data_loader.py
+++ b/data_loader.py
@@ -5,15 +5,13 @@ import pandas as pd
 from langchain_community.vectorstores import Chroma
 from langchain_experimental.open_clip import OpenCLIPEmbeddings
 
-# Load environment variables from .env
-LISTINGS_CSV = os.getenv("LISTINGS_CSV", "listings.csv")  
-VECTOR_DB_DIR = os.getenv("VECTOR_DB_DIR", "chroma_db")
-IMAGES_DIR = os.getenv("IMAGES_DIR", "images")
-CACHE_FILE = os.getenv("CACHE_FILE", "listings_cache.pkl")
-DEFAULT_IMAGE = os.getenv("DEFAULT_IMAGE", "default_image.png")
+from config import LISTINGS_CSV, VECTOR_DB_DIR, CACHE_FILE
 
 def load_dataframe():
-    """Loads the listings DataFrame from CSV or cache, returns df and df_dict."""
+    """Load the property listings DataFrame from CSV or cache.
+
+    Returns a tuple ``(df, df_dict)`` where ``df_dict`` maps IDs to row data.
+    """
     try:
         if os.path.exists(CACHE_FILE):
             df = joblib.load(CACHE_FILE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 langchain==0.1.9
 openai==0.28.1
 pydantic>=1.10.12
+python-dotenv>=1.0.0
 pytest>=7.4.0
 sentence-transformers>=2.2.0
 transformers>=4.31.0

--- a/search.py
+++ b/search.py
@@ -1,6 +1,10 @@
 import os
 import logging
+from typing import Any, List, Tuple
+
 import gradio as gr
+
+from config import IMAGES_DIR, DEFAULT_IMAGE, TOP_K
 
 # We'll assume data_loader has provided us df, df_dict, db
 df = None
@@ -10,7 +14,7 @@ db = None
 # We'll keep a global for last_search_ids
 last_search_ids = []
 
-def init_globals(the_df, the_df_dict, the_db):
+def init_globals(the_df: Any, the_df_dict: dict[str, Any], the_db: Any) -> None:
     """
     Call this once in app.py after you load the data and DB 
     so we can store them in our module-level variables.
@@ -20,7 +24,13 @@ def init_globals(the_df, the_df_dict, the_db):
     df_dict = the_df_dict
     db = the_db
 
-def search_listings(budget, bedrooms, neighborhood, features, property_type):
+def search_listings(
+    budget: str,
+    bedrooms: str,
+    neighborhood: str,
+    features: str,
+    property_type: str,
+) -> list[tuple[str, str]]:
     """
     Searches vector database based on user input preferences and returns matched listings 
     in the form of a list of (image_path, label) tuples for Gradio's Gallery.
@@ -40,23 +50,16 @@ def search_listings(budget, bedrooms, neighborhood, features, property_type):
     if db is None:
         return [("⚠️ No DB Found", "Please check vector DB initialization")]
 
-    search_results = db.similarity_search(query, k=5)
+    search_results = db.similarity_search(query, k=TOP_K)
     results = []
 
     for res in search_results:
         prop_id = res.metadata["id"]
         last_search_ids.append(prop_id)
 
-        # Check if there's an image
-        images_dir = os.getenv("IMAGES_DIR", "images")
-        default_image = os.getenv("DEFAULT_IMAGE", "default_image.png")
-        img_path = os.path.join(images_dir, f"{prop_id}.png")
+        img_path = os.path.join(IMAGES_DIR, f"{prop_id}.png")
         if not os.path.exists(img_path):
-            img_path = default_image
-
-        # Retrieve the row from df_dict (avoid slow df lookups)
-        row_data = df_dict.get(prop_id, {})
-        description = row_data.get("description", "No description available.")
+            img_path = DEFAULT_IMAGE
 
         results.append((img_path, f"Listing ID: {prop_id}"))
 
@@ -66,7 +69,7 @@ def search_listings(budget, bedrooms, neighborhood, features, property_type):
     return results
 
 def personalize_description(evt: gr.SelectData) -> str:
-    """Return a description for the selected gallery item."""
+    """Return the description for the item selected in the gallery."""
     global last_search_ids, df_dict
 
     try:


### PR DESCRIPTION
## Summary
- centralize environment variables in new `config.py`
- remove redundant `load_dotenv` call in `app.py`
- use config values in `data_loader.py` and `search.py`
- add type hints to `search_listings`
- document configurable settings in README

## Testing
- `python -m py_compile app.py data_loader.py search.py ui.py config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68433efe31c08328b5b9d79ec515d543